### PR TITLE
Multimedia Data

### DIFF
--- a/Sources/MiseEnPlace/AnyIngredient.swift
+++ b/Sources/MiseEnPlace/AnyIngredient.swift
@@ -7,6 +7,7 @@ public struct AnyIngredient: Ingredient {
     public var name: String?
     public var commentary: String?
     public var classification: String?
+    public var imageData: Data?
     public var imagePath: String?
     public var volume: Double
     public var weight: Double
@@ -20,6 +21,7 @@ public struct AnyIngredient: Ingredient {
         name: String? = nil,
         commentary: String? = nil,
         classification: String? = nil,
+        imageData: Data? = nil,
         imagePath: String? = nil,
         volume: Double = 1.0,
         weight: Double = 1.0,
@@ -32,6 +34,7 @@ public struct AnyIngredient: Ingredient {
         self.name = name
         self.commentary = commentary
         self.classification = classification
+        self.imageData = imageData
         self.imagePath = imagePath
         self.volume = volume
         self.weight = weight
@@ -46,6 +49,7 @@ public struct AnyIngredient: Ingredient {
         self.name = ingredient.name
         self.commentary = ingredient.commentary
         self.classification = ingredient.classification
+        self.imageData = ingredient.imageData
         self.imagePath = ingredient.imagePath
         self.volume = ingredient.volume
         self.weight = ingredient.weight

--- a/Sources/MiseEnPlace/AnyProcedureElement.swift
+++ b/Sources/MiseEnPlace/AnyProcedureElement.swift
@@ -8,6 +8,7 @@ public struct AnyProcedureElement: ProcedureElement {
     public var commentary: String?
     public var classification: String?
     public var sequence: Int
+    public var imageData: Data?
     public var imagePath: String?
     public var inverseRecipe: Recipe?
     
@@ -19,6 +20,7 @@ public struct AnyProcedureElement: ProcedureElement {
         commentary: String? = nil,
         classification: String? = nil,
         sequence: Int = 0,
+        imageData: Data? = nil,
         imagePath: String? = nil,
         inverseRecipe: Recipe? = nil
     ) {
@@ -29,6 +31,7 @@ public struct AnyProcedureElement: ProcedureElement {
         self.commentary = commentary
         self.classification = classification
         self.sequence = sequence
+        self.imageData = imageData
         self.imagePath = imagePath
         self.inverseRecipe = inverseRecipe
     }
@@ -41,6 +44,7 @@ public struct AnyProcedureElement: ProcedureElement {
         self.commentary = procedureElement.commentary
         self.classification = procedureElement.classification
         self.sequence = procedureElement.sequence
+        self.imageData = procedureElement.imageData
         self.imagePath = procedureElement.imagePath
         self.inverseRecipe = procedureElement.inverseRecipe.map { AnyRecipe($0) }
     }

--- a/Sources/MiseEnPlace/AnyRecipe.swift
+++ b/Sources/MiseEnPlace/AnyRecipe.swift
@@ -7,6 +7,7 @@ public struct AnyRecipe: Recipe {
     public var name: String?
     public var commentary: String?
     public var classification: String?
+    public var imageData: Data?
     public var imagePath: String?
     public var amount: Double
     public var unit: MeasurementUnit
@@ -20,6 +21,7 @@ public struct AnyRecipe: Recipe {
         name: String? = nil,
         commentary: String? = nil,
         classification: String? = nil,
+        imageData: Data? = nil,
         imagePath: String? = nil,
         amount: Double = 1.0,
         unit: MeasurementUnit = .noUnit,
@@ -32,6 +34,7 @@ public struct AnyRecipe: Recipe {
         self.name = name
         self.commentary = commentary
         self.classification = classification
+        self.imageData = imageData
         self.imagePath = imagePath
         self.amount = amount
         self.unit = unit
@@ -46,6 +49,7 @@ public struct AnyRecipe: Recipe {
         self.name = recipe.name
         self.commentary = recipe.commentary
         self.classification = recipe.classification
+        self.imageData = recipe.imageData
         self.imagePath = recipe.imagePath
         self.amount = recipe.amount
         self.unit = recipe.unit

--- a/Sources/MiseEnPlace/MediaManager.swift
+++ b/Sources/MiseEnPlace/MediaManager.swift
@@ -88,6 +88,15 @@ public struct MediaManager {
         return imageDirectory.appendingPathComponent(imagePath)
     }
     
+    /// Bytes representing the multimedia.
+    public func data(for multimedia: any Multimedia) throws -> Data? {
+        guard let url = try imageURL(for: multimedia) else {
+            return nil
+        }
+        
+        return try Data(contentsOf: url)
+    }
+    
     /// Remove a local image for a specific `Multimedia` item.
     public func removeImage(for multimedia: Multimedia) throws {
         guard let url = try imageURL(for: multimedia) else {

--- a/Sources/MiseEnPlace/Multimedia.swift
+++ b/Sources/MiseEnPlace/Multimedia.swift
@@ -9,7 +9,10 @@ import Foundation
 /// var imagePath: String? { get set }
 /// ```
 ///
+/// > note `imageData` & `imagePath` may be deprecated in **MiseEnPlace 6.0** in favor of
+///   a `[Media]` collection allowing for multiple pieces of media.
 public protocol Multimedia {
+    var imageData: Data? { get set }
     var imagePath: String? { get set }
     @available(*, deprecated, message: "`MediaManager` should be used to persist `Multimedia`.")
     var fileManager: FileManager { get }


### PR DESCRIPTION
Adds `imageData` to the `Multimedia` protocol. The goal is to make it easier to represent the underlying media content rather than rely of reading from disk using the image path.